### PR TITLE
Add Windows CI/CD support

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -41,9 +41,9 @@ jobs:
         # Run Build operation
         - name: Compiling Code
           run: |
-             gradlew.bat clean build --info --stacktrace
+             ./gradlew.bat clean build --info --stacktrace
 
         # Run Test operation
         - name: Testing Code
           run: |
-            gradlew.bat clean test --info --stacktrace
+            ./gradlew.bat clean test --info --stacktrace

--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -4,7 +4,7 @@ name: BuildTest
 on: push
 
 jobs:
-  BuildTest:
+  BuildLinux:
     # Name the Job
     name: Build the code, Test code using Gradlew
 
@@ -25,3 +25,25 @@ jobs:
       - name: Testing Code
         run: |
           ./gradlew clean test --info --stacktrace
+
+  BuildWindows:
+      # Name the Job
+      name: Build the code, Test code using Gradlew
+
+      # Set the type of machine to run on
+      runs-on: windows-latest
+
+      steps:
+        # Checks out a copy of your repository on the ubuntu-latest machine
+        - name: Checkout code
+          uses: actions/checkout@v2
+
+        # Run Build operation
+        - name: Compiling Code
+          run: |
+             gradlew.bat clean build --info --stacktrace
+
+        # Run Test operation
+        - name: Testing Code
+          run: |
+            gradlew.bat clean test --info --stacktrace


### PR DESCRIPTION
Since we are only testing on ubuntu, there is certain problem, such as testing environment difference.

Enabling Windows CI/CD support will let dev know if their code isn't OS-wide.
Those code / tests should work on Linux, macOS, Windows