### PR TITLE
Implement Java Virtual Machine - Based - File Tree Watcher

### DIFF
--- a/src/main/kotlin/com/navi/server/domain/FileRepository.kt
+++ b/src/main/kotlin/com/navi/server/domain/FileRepository.kt
@@ -2,6 +2,7 @@ package com.navi.server.domain
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 
 interface FileRepository : JpaRepository<FileEntity, Long> {
     @Query("SELECT f FROM FileEntity f ORDER BY f.id DESC")
@@ -9,4 +10,10 @@ interface FileRepository : JpaRepository<FileEntity, Long> {
 
     @Query("FROM FileEntity WHERE prevToken= ?1")
     fun findInsideFiles(token: String) : List<FileEntity>
+
+    @Transactional(readOnly = true)
+    fun findByToken(token: String): FileEntity
+
+    @Transactional(readOnly = false)
+    fun deleteByToken(token: String): Long
 }

--- a/src/main/kotlin/com/navi/server/dto/FileSaveRequestDTO.kt
+++ b/src/main/kotlin/com/navi/server/dto/FileSaveRequestDTO.kt
@@ -14,6 +14,18 @@ class FileSaveRequestDTO(
     var fileSize: String
 ) {
 
+    constructor(responseDTO: FileResponseDTO): this(
+        id = responseDTO.id,
+        fileName = responseDTO.fileName,
+        fileType = responseDTO.fileType,
+        mimeType = responseDTO.mimeType,
+        token = responseDTO.token,
+        prevToken = responseDTO.prevToken,
+        lastModifiedTime = responseDTO.lastModifiedTime,
+        fileCreatedDate = responseDTO.fileCreatedDate,
+        fileSize = responseDTO.fileSize
+    )
+
     fun toEntity(): FileEntity {
         return FileEntity(
             id = this.id,

--- a/src/main/kotlin/com/navi/server/service/FileService.kt
+++ b/src/main/kotlin/com/navi/server/service/FileService.kt
@@ -5,8 +5,12 @@ import com.navi.server.domain.FileRepository
 import com.navi.server.dto.FileResponseDTO
 import com.navi.server.dto.FileSaveRequestDTO
 import org.springframework.stereotype.Service
+import java.security.MessageDigest
 import java.util.ArrayList
 import java.util.stream.Collectors
+import javax.xml.bind.DatatypeConverter
+import kotlin.math.log
+import kotlin.math.pow
 
 @Service
 class FileService(val fileRepository: FileRepository) {
@@ -42,6 +46,30 @@ class FileService(val fileRepository: FileRepository) {
             .collect(Collectors.toList())
     }
 
+    fun deleteByToken(token: String): Long {
+        return fileRepository.deleteByToken(token)
+    }
+
+    fun findByToken(token: String): FileResponseDTO {
+        return FileResponseDTO(fileRepository.findByToken(token))
+    }
+
     var rootToken: String? = null
 
+    fun getSHA256(input: String): String {
+        val messageDigest: MessageDigest = MessageDigest.getInstance("SHA-256").also {
+            it.update(input.toByteArray())
+        }
+        return DatatypeConverter.printHexBinary(messageDigest.digest())
+    }
+
+    fun convertSize(fileSize: Long): String {
+        val fileUnit: String = "KMGTE"
+        val logValue: Int = log(fileSize.toDouble(), 1024.0).toInt()
+        if (logValue == 0 || fileSize == 0.toLong()) {
+            return "${fileSize}B"
+        }
+        val calculatedValue: Double = fileSize / 1024.0.pow(logValue)
+        return String.format("%.1f%ciB", calculatedValue, fileUnit[logValue-1])
+    }
 }

--- a/src/main/kotlin/com/navi/server/watcher/InternalFileWatcher.kt
+++ b/src/main/kotlin/com/navi/server/watcher/InternalFileWatcher.kt
@@ -1,0 +1,10 @@
+package com.navi.server.watcher
+
+import com.navi.server.service.FileService
+
+abstract class InternalFileWatcher(val fileToWatch: String = "/tmp", val fileService: FileService) {
+    var isContinue: Boolean = true
+
+    abstract fun watchFolder()
+    abstract fun closeWatcher()
+}

--- a/src/main/kotlin/com/navi/server/watcher/JVMWatcher.kt
+++ b/src/main/kotlin/com/navi/server/watcher/JVMWatcher.kt
@@ -61,11 +61,11 @@ class JVMWatcher(rootDirectory: String, fileService: FileService): InternalFileW
                     val kind = event.kind()
                     val absolutePath: Path = parentPath.resolve(event.context() as Path)
                     val fileObject: File = File(absolutePath.toUri())
-                    val basicFileAttribute: BasicFileAttributes = Files.readAttributes(fileObject.toPath(), BasicFileAttributes::class.java)
 
                     when (kind) {
                         // Note: FileSaveRequestDto does not require ID anyway though
                         StandardWatchEventKinds.ENTRY_CREATE -> {
+                            val basicFileAttribute: BasicFileAttributes = Files.readAttributes(fileObject.toPath(), BasicFileAttributes::class.java)
                             fileService.save(FileSaveRequestDTO(
                                 fileName = absolutePath.toString(),
                                 fileType = if (fileObject.isDirectory) "Folder" else "File",
@@ -90,6 +90,7 @@ class JVMWatcher(rootDirectory: String, fileService: FileService): InternalFileW
                             println("Deleted: $absolutePath")
                         }
                         StandardWatchEventKinds.ENTRY_MODIFY -> {
+                            val basicFileAttribute: BasicFileAttributes = Files.readAttributes(fileObject.toPath(), BasicFileAttributes::class.java)
                             val token: String = fileService.getSHA256(fileObject.absolutePath)
                             val toEdit: FileResponseDTO = fileService.findByToken(token).also {
                                 it.lastModifiedTime = fileObject.lastModified()

--- a/src/main/kotlin/com/navi/server/watcher/JVMWatcher.kt
+++ b/src/main/kotlin/com/navi/server/watcher/JVMWatcher.kt
@@ -1,0 +1,113 @@
+package com.navi.server.watcher
+
+import com.navi.server.dto.FileResponseDTO
+import com.navi.server.dto.FileSaveRequestDTO
+import com.navi.server.service.FileService
+import com.sun.nio.file.SensitivityWatchEventModifier
+import org.apache.tika.Tika
+import java.io.File
+import java.nio.file.*
+import java.nio.file.attribute.BasicFileAttributes
+import java.text.SimpleDateFormat
+
+/**
+ * This class is for OS does not support C/C++ Based Native File Watching Service.
+ * JVM Should just work for any OS supports Java, but it is relatively slower comparing to
+ * Native File Watching Service.
+ */
+class JVMWatcher(rootDirectory: String, fileService: FileService): InternalFileWatcher(rootDirectory, fileService) {
+    var watchKey: WatchKey? = null
+    private val tika: Tika = Tika()
+    val simpleDateFormat: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd-HH:mm:ss")
+
+    override fun watchFolder() {
+        println("Starting")
+        val map: HashMap<WatchKey, Path> = HashMap()
+        val targetPath: String = fileToWatch
+        val watchService: WatchService = FileSystems.getDefault().newWatchService()
+
+        File(targetPath).walk().forEach { it ->
+            if (it.isDirectory) {
+                Paths.get(it.absolutePath).also { pathTmp ->
+                    val key: WatchKey = pathTmp.register(
+                        watchService,
+                        arrayOf<WatchEvent.Kind<*>>(
+                            StandardWatchEventKinds.ENTRY_MODIFY,
+                            StandardWatchEventKinds.ENTRY_CREATE,
+                            StandardWatchEventKinds.ENTRY_DELETE
+                        ),
+                        SensitivityWatchEventModifier.HIGH
+                    )
+                    map[key] = pathTmp
+                    println("Registered: ${pathTmp.toAbsolutePath()}")
+                }
+            }
+        }
+
+        while (isContinue) {
+            try {
+                watchKey = watchService.take() // Start wait
+            } catch (e: InterruptedException) {
+                println("Interrupted!")
+            }
+            val parentPath: Path = map[watchKey] ?: run {
+                println("ERROR: NO KEY")
+                return
+            }
+            val events = watchKey?.pollEvents() // Get Events
+
+            if (events != null) {
+                for (event in events) {
+                    val kind = event.kind()
+                    val absolutePath: Path = parentPath.resolve(event.context() as Path)
+                    val fileObject: File = File(absolutePath.toUri())
+                    val basicFileAttribute: BasicFileAttributes = Files.readAttributes(fileObject.toPath(), BasicFileAttributes::class.java)
+
+                    when (kind) {
+                        // Note: FileSaveRequestDto does not require ID anyway though
+                        StandardWatchEventKinds.ENTRY_CREATE -> {
+                            fileService.save(FileSaveRequestDTO(
+                                fileName = absolutePath.toString(),
+                                fileType = if (fileObject.isDirectory) "Folder" else "File",
+                                mimeType = if(fileObject.isDirectory) "Folder" else {
+                                    try {
+                                        tika.detect(fileObject)
+                                    } catch (e: Exception) {
+                                        println("Failed to detect mimeType for: ${e.message}")
+                                        "File"
+                                    }
+                                },
+                                token = fileService.getSHA256(fileObject.absolutePath),
+                                prevToken = fileService.getSHA256(fileObject.parent),
+                                lastModifiedTime = fileObject.lastModified(),
+                                fileCreatedDate = simpleDateFormat.format(basicFileAttribute.creationTime().toMillis()),
+                                fileSize = fileService.convertSize(basicFileAttribute.size())
+                            ))
+                            println("Created: $absolutePath")
+                        }
+                        StandardWatchEventKinds.ENTRY_DELETE -> {
+                            fileService.deleteByToken(fileService.getSHA256(fileObject.absolutePath))
+                            println("Deleted: $absolutePath")
+                        }
+                        StandardWatchEventKinds.ENTRY_MODIFY -> {
+                            val token: String = fileService.getSHA256(fileObject.absolutePath)
+                            val toEdit: FileResponseDTO = fileService.findByToken(token).also {
+                                it.lastModifiedTime = fileObject.lastModified()
+                                it.fileSize = fileService.convertSize(basicFileAttribute.size())
+                            }
+                            fileService.save(FileSaveRequestDTO(toEdit))
+                            println("Modified: $absolutePath")
+                        }
+                    }
+                }
+            }
+            watchKey?.reset()
+        }
+    }
+
+    override fun closeWatcher() {
+        println("Canceled")
+        isContinue = false
+        watchKey?.cancel()
+    }
+}

--- a/src/test/kotlin/com/navi/server/web/FileApiControllerTest.kt
+++ b/src/test/kotlin/com/navi/server/web/FileApiControllerTest.kt
@@ -6,6 +6,7 @@ import com.navi.server.domain.FileEntity
 import com.navi.server.domain.FileRepository
 import com.navi.server.dto.FileResponseDTO
 import com.navi.server.dto.FileSaveRequestDTO
+import com.navi.server.service.FileService
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,6 +40,9 @@ class FileApiControllerTest {
 
     @Autowired
     private lateinit var fileConfigurationComponent: FileConfigurationComponent
+
+    @Autowired
+    private lateinit var fileService: FileService
 
     private lateinit var trashRootObject: File
 
@@ -141,7 +145,7 @@ class FileApiControllerTest {
 
         // Assert
         assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(responseEntity.body).isEqualTo(fileConfigurationComponent.getSHA256(fileConfigurationComponent.serverRoot))
+        assertThat(responseEntity.body).isEqualTo(fileService.getSHA256(fileConfigurationComponent.serverRoot))
 
     }
 
@@ -182,7 +186,7 @@ class FileApiControllerTest {
 
 
         // Api test 1 :: under Root
-        val rootToken = fileConfigurationComponent.getSHA256(fileConfigurationComponent.serverRoot)
+        val rootToken = fileService.getSHA256(fileConfigurationComponent.serverRoot)
         val url = "http://localhost:$port/api/navi/findInsideFiles/${rootToken}"
         var responseEntity : ResponseEntity<Array<FileResponseDTO>> = restTemplate.getForEntity(url, Array<FileResponseDTO>::class.java)
 
@@ -197,7 +201,7 @@ class FileApiControllerTest {
 
 
         //Api test 2 :: under folderName
-        val folderToken = fileConfigurationComponent.getSHA256(folderPath)
+        val folderToken = fileService.getSHA256(folderPath)
         val url2 = "http://localhost:$port/api/navi/findInsideFiles/${folderToken}"
         var responseEntity2 : ResponseEntity<Array<FileResponseDTO>> = restTemplate.getForEntity(url2, Array<FileResponseDTO>::class.java)
 


### PR DESCRIPTION
Basically Server needs to check whether its root folder tree is either
- Created
- Modified
- Deleted

Therefore, this PR will implement Root-Tree watcher for this server.

Since, this is 'Java Virtual Machine' based watcher, therefore it is relatively slower comparing to OS-Specific Native file watcher.

Here is native-way to implement File Tree Watcher:
- Linux: INotify
- macOS: Kernel Queue + FSEvents
- Windows[Native C++]: FindFirstChangeNotification
- Windows[Native .Net Framework]: System.io.FileSystemWatcher
